### PR TITLE
Remove symfony dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "symfony/symfony": "~2.3",
         "solution/pipeline-builder": "dev-master",
         "doctrine/mongodb-odm-bundle": "~3.0"
     },


### PR DESCRIPTION
Hey,

would be great if the dependency for symfony could be removed in the composer.json fil. I couldn't find a reason why to require the whole symfony/symfony package as dependency, which is about 40MB big.

I recognized this when I was adding your package as dependency and composer installed symfony/symfony package even though I required only the symfony components I needed.